### PR TITLE
fix typo in clone directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This splicing analysis pipeline is a novel compilation of computational biology 
 ## Downloading the project
 Open a terminal session and enter the following:
 ```
-git clone https://github.com/breecoffey/RNA_Seq_Splicing-Analysis-Pipeline.git
+git clone https://github.com/breecoffey/RNA-Seq-Splicing-Analysis-Pipeline.git
 ```
 ## Input Files
 ### `.vcf.gz`,`.bam`


### PR DESCRIPTION
While testing your code, I noticed a typo in this `git clone` command, just need to replace the `_` with `-`. The rest of your test example worked great. Thanks.